### PR TITLE
fix handling camera images when targetSdk is 24

### DIFF
--- a/lib/src/main/java/com/github/oliveiradev/lib/OverlapActivity.java
+++ b/lib/src/main/java/com/github/oliveiradev/lib/OverlapActivity.java
@@ -2,11 +2,14 @@ package com.github.oliveiradev.lib;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.v4.content.FileProvider;
 
 import com.github.oliveiradev.lib.shared.Constants;
 import com.github.oliveiradev.lib.shared.TypeRequest;
@@ -15,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * Created by felipe on 03/05/16.
@@ -53,30 +57,19 @@ public class OverlapActivity extends Activity {
     private void camera() {
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (takePictureIntent.resolveActivity(getPackageManager()) != null) {
-            File photoFile = null;
-            try {
-                photoFile = createImageTempFile();
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
-            fileUri = Uri.fromFile(photoFile);
+            fileUri = createImageUri();
             takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, fileUri);
             startActivityForResult(takePictureIntent, Constants.REQUEST_CODE_TAKE_PICURE);
         }
+
     }
 
-
-    @SuppressLint("SimpleDateFormat")
-    private File createImageTempFile() throws IOException {
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-        String imageFileName = "JPEG_" + timeStamp + "_";
-        File storageDir = Environment.getExternalStoragePublicDirectory(
-                Environment.DIRECTORY_PICTURES);
-        return File.createTempFile(
-                imageFileName,  /* prefix */
-                ".jpg",         /* suffix */
-                storageDir      /* directory */
-        );
+    private Uri createImageUri() {
+        ContentResolver contentResolver = getContentResolver();
+        ContentValues cv = new ContentValues();
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(new Date());
+        cv.put(MediaStore.Images.Media.TITLE, timeStamp);
+        return contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, cv);
     }
 
 


### PR DESCRIPTION
When target sdk is 24 you can't use file:// URI.
This used MediaStore URI.
Similar to this:
https://github.com/MLSDev/RxImagePicker/pull/18/commits/0fca624be87173c6c9cb1b60460a199afc568f73