### PR TITLE
- remove minifying

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.1"
+    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
     compile project(':lib')
 }

--- a/app/src/main/java/com/github/oliveiradev/rxphoto/MainActivity.java
+++ b/app/src/main/java/com/github/oliveiradev/rxphoto/MainActivity.java
@@ -114,11 +114,11 @@ public class MainActivity extends AppCompatActivity {
                     disposable.dispose();
                 }
                 disposable = Rx2Photo.with(v.getContext())
-                        .requestMultiUri()
+                        .requestMultiPath()
                         .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(new Consumer<List<Uri>>() {
+                        .subscribe(new Consumer<List<String>>() {
                             @Override
-                            public void accept(List<Uri> bitmap) throws Exception {
+                            public void accept(List<String> bitmap) throws Exception {
                                 Log.d("TAG", String.valueOf(bitmap.size()));
                             }
                         }, new Consumer<Throwable>() {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.20'
+    ext.kotlin_version = '1.2.21'
     repositories {
         jcenter()
     }
@@ -41,8 +41,8 @@ kapt {
 }
 
 dependencies {
-    implementation "io.reactivex.rxjava2:rxjava:2.1.8"
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.1"
+    implementation "io.reactivex.rxjava2:rxjava:2.1.9"
+    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
     compileOnly 'com.android.support:appcompat-v7:27.0.2'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -25,13 +25,8 @@ android {
         versionName "1.0"
     }
     buildTypes {
-        debug {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/lib/src/main/java/com/github/oliveiradev/lib/Rx2Photo.kt
+++ b/lib/src/main/java/com/github/oliveiradev/lib/Rx2Photo.kt
@@ -135,6 +135,7 @@ open class Rx2Photo(private val context: Context) {
      * @param typeRequest - selected source for emitter
      * @return - observable that emits a single uri
      */
+    @Deprecated(message = "Because Google Photo Content Provider forbids the use of it ury in other contexts, in addition, from which the call was made")
     fun requestUri(typeRequest: TypeRequest): Observable<Uri> {
         response = URI
         startOverlapActivity(typeRequest)
@@ -171,6 +172,7 @@ open class Rx2Photo(private val context: Context) {
      * Request for list of uris
      * @return - observable that emits a list of uris
      */
+    @Deprecated(message = "Because Google Photo Content Provider forbids the use of it ury in other contexts, in addition, from which the call was made")
     fun requestMultiUri(): Observable<List<Uri>> {
         response = URI
         startOverlapActivity(TypeRequest.COMBINE_MULTIPLE)

--- a/lib/src/main/java/com/github/oliveiradev/lib/shared/ResponseType.kt
+++ b/lib/src/main/java/com/github/oliveiradev/lib/shared/ResponseType.kt
@@ -4,5 +4,5 @@ package com.github.oliveiradev.lib.shared
  * Created by Genius on 03.12.2017.
  */
 enum class ResponseType {
-    BITMAP, URI, THUMB
+    BITMAP, URI, THUMB, PATH
 }

--- a/lib/src/main/java/com/github/oliveiradev/lib/util/FileUtils.java
+++ b/lib/src/main/java/com/github/oliveiradev/lib/util/FileUtils.java
@@ -1,0 +1,230 @@
+package com.github.oliveiradev.lib.util;
+
+import android.annotation.SuppressLint;
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.DatabaseUtils;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.webkit.MimeTypeMap;
+
+import java.io.File;
+
+/**
+ * @author Peli
+ * @author paulburke (ipaulpro)
+ * @version 2013-12-11
+ */
+public class FileUtils {
+    private FileUtils() {
+    } //private constructor to enforce Singleton pattern
+
+    /**
+     * TAG for log messages.
+     */
+    static final String TAG = "FileUtils";
+    private static final boolean DEBUG = false; // Set to true to enable logging
+
+    /**
+     * @return Whether the URI is a local one.
+     */
+    public static boolean isLocal(String url) {
+        if (url != null && !url.startsWith("http://") && !url.startsWith("https://")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     * @author paulburke
+     */
+    public static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     * @author paulburke
+     */
+    public static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     * @author paulburke
+     */
+    public static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is Google Photos.
+     */
+    public static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context       The context.
+     * @param uri           The Uri to query.
+     * @param selection     (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     * @author paulburke
+     */
+    public static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                if (DEBUG)
+                    DatabaseUtils.dumpCursor(cursor);
+
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+    /**
+     * Get a file path from a Uri. This will get the the path for Storage Access
+     * Framework Documents, as well as the _data field for the MediaStore and
+     * other file-based ContentProviders.<br>
+     * <br>
+     * Callers should check whether the path is local before assuming it
+     * represents a local file.
+     *
+     * @param context The context.
+     * @param uri     The Uri to query.
+     * @author paulburke
+     * @see #isLocal(String)
+     * @see #getFile(Context, Uri)
+     */
+    @SuppressLint("NewApi")
+    public static String getPath(final Context context, final Uri uri) {
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+
+        // DocumentProvider
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+
+                // TODO handle non-primary volumes
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[]{
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+            // Return the remote address
+            if (isGooglePhotosUri(uri))
+                return uri.getLastPathSegment();
+
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert Uri into File, if possible.
+     *
+     * @return file A local file that the Uri was pointing to, or null if the
+     * Uri is unsupported or pointed to a remote resource.
+     * @author paulburke
+     * @see #getPath(Context, Uri)
+     */
+    public static File getFile(Context context, Uri uri) {
+        if (uri != null) {
+            String path = getPath(context, uri);
+            if (path != null && isLocal(path)) {
+                return new File(path);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get Mime type from uri file
+     * @param uri - file uri
+     * @return - Mime type in string
+     */
+    public static String getMimeType(Context context, Uri uri) {
+        String mimeType;
+        if (uri.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
+            ContentResolver cr = context.getContentResolver();
+            mimeType = cr.getType(uri);
+        } else {
+            String fileExtension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+            mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension.toLowerCase());
+        }
+        return mimeType;
+    }
+}


### PR DESCRIPTION
Google Photo Content Provider has strict policy about URI from them. Because requestUri marked as deprecated and has been added requestPath in both variants